### PR TITLE
Migrate to built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.5
+
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
+
 # 1.2.4
 
 - Android compileSdkVersion 36

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'dev.rexios.wear_plus'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,8 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-//apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 36
@@ -42,14 +38,16 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = '11'
-    }
     namespace "dev.rexios.wear_plus"
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
+
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.wear:wear:1.3.0'
     implementation 'com.google.android.support:wearable:2.9.0'
     compileOnly 'com.google.android.wearable:wearable:2.9.0'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -32,10 +31,6 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -59,6 +54,12 @@ android {
         }
     }
     namespace 'dev.rexios.wear_plus_example'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
 }
 
 flutter {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -4,3 +4,5 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.newDsl=false
+android.builtInKotlin=false

--- a/lib/src/ambient_widget.dart
+++ b/lib/src/ambient_widget.dart
@@ -11,11 +11,8 @@ enum WearMode {
 }
 
 /// Builds a child for [AmbientMode]
-typedef AmbientModeWidgetBuilder = Widget Function(
-  BuildContext context,
-  WearMode mode,
-  Widget? child,
-);
+typedef AmbientModeWidgetBuilder =
+    Widget Function(BuildContext context, WearMode mode, Widget? child);
 
 /// Widget that listens for when a Wear device enters full power or ambient mode,
 /// and provides this in a builder. It optionally takes an [onUpdate] function that's

--- a/lib/src/shape_widget.dart
+++ b/lib/src/shape_widget.dart
@@ -11,21 +11,14 @@ enum WearShape {
 }
 
 /// Builds a child for a [WatchShape]
-typedef WatchShapeBuilder = Widget Function(
-  BuildContext context,
-  WearShape shape,
-  Widget? child,
-);
+typedef WatchShapeBuilder =
+    Widget Function(BuildContext context, WearShape shape, Widget? child);
 
 /// Builder widget for watch shapes
 @immutable
 class WatchShape extends StatefulWidget {
   /// Constructor
-  const WatchShape({
-    super.key,
-    required this.builder,
-    this.child,
-  });
+  const WatchShape({super.key, required this.builder, this.child});
 
   /// Built when the shape changes
   final WatchShapeBuilder builder;
@@ -77,10 +70,7 @@ class _WatchShapeState extends State<WatchShape> {
 
 class _InheritedShape extends InheritedWidget {
   /// Constructor
-  const _InheritedShape({
-    required this.shape,
-    required super.child,
-  });
+  const _InheritedShape({required this.shape, required super.child});
 
   final WearShape shape;
 

--- a/lib/src/wear.dart
+++ b/lib/src/wear.dart
@@ -32,8 +32,10 @@ class Wear {
     switch (call.method) {
       case 'onEnterAmbient':
         final args = (call.arguments as Map).cast<String, bool>();
-        final details =
-            AmbientDetails(args['burnInProtection']!, args['lowBitAmbient']!);
+        final details = AmbientDetails(
+          args['burnInProtection']!,
+          args['lowBitAmbient']!,
+        );
         _notifyAmbientCallbacks((callback) => callback.onEnterAmbient(details));
       case 'onExitAmbient':
         _notifyAmbientCallbacks((callback) => callback.onExitAmbient());
@@ -87,10 +89,9 @@ class Wear {
   ///
   Future<void> setAutoResumeEnabled(bool enabled) async {
     try {
-      await _channel.invokeMethod<String>(
-        'setAutoResumeEnabled',
-        {'enabled': enabled},
-      );
+      await _channel.invokeMethod<String>('setAutoResumeEnabled', {
+        'enabled': enabled,
+      });
     } on PlatformException catch (e, st) {
       debugPrint('Error calling setAutoResumeEnabled: $e\n$st');
       rethrow;
@@ -100,10 +101,9 @@ class Wear {
   /// Sets whether this activity is currently in a state that supports ambient offload mode.
   Future<void> setAmbientOffloadEnabled(bool enabled) async {
     try {
-      await _channel.invokeMethod<String>(
-        'setAmbientOffloadEnabled',
-        {'enabled': enabled},
-      );
+      await _channel.invokeMethod<String>('setAmbientOffloadEnabled', {
+        'enabled': enabled,
+      });
     } on PlatformException catch (e, st) {
       debugPrint('Error calling setAmbientOffloadEnabled: $e\n$st');
       rethrow;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: wear_plus
 description: An actively maintained plugin that offers Flutter support for Wear OS by Google
-version: 1.2.4
+version: 1.2.5
 homepage: https://github.com/Rexios80/wear_plus
 
 environment:
-  sdk: ^3.0.0
-  flutter: ">=2.5.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Migrates the plugin to built-in Kotlin: removes the explicit Kotlin Gradle Plugin usage (`apply plugin: 'kotlin-android'`, the `kotlin-gradle-plugin` buildscript classpath, `ext.kotlin_version`, and the explicit `kotlin-stdlib` dependency) and adds a `kotlin { compilerOptions { jvmTarget = ... } }` block.
- Raises minimum SDK to Flutter 3.44 / Dart 3.12, patch-bumps the version, and adds a CHANGELOG entry.
- Migrates the example app per the [app-developer guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers) (adds `android.builtInKotlin=false` / `android.newDsl=false`, removes the `kotlin-android` plugin and `kotlinOptions` where present). No AGP upgrade.

See the [plugin-author migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

## Test plan
- [ ] CI passes
- [ ] Example builds after the separate AGP 9 upgrade

Made with [Cursor](https://cursor.com)